### PR TITLE
Add hideEmptyPagesOnPager boolean property, defaulting to false.

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
             columnPicker: true,         //Show the columnPicker button
             pageSizes: [1,5,8,12,200],  //Set custom pageSizes. Leave empty array to hide button.
             hidePagerOnEmpty: true,     //Removes the pager if data is empty.
+            hideEmptyPagesOnPager: true,//Removes empty pages from pager (instead of disabling them - overrides 5 page minimum when true)
             checkboxes: true,           //Make rows checkable. (Note. You need a column with the 'unique' property)
             checkAllToggle:true,        //Show the check-all toggle
             preFill: true,              //Initially fills the table with empty rows (as many as the pagesize).

--- a/jquery.watable.js
+++ b/jquery.watable.js
@@ -42,6 +42,7 @@
             actions: '', //holds action links
             pageSize: 10, //current pagesize
             pageSizes: [10, 20, 30, 40, 50, 'All'], //available pagesizes
+            hideEmptyPagesOnPager: false, //remove pages from pager if no rows (overrides 5 page minimum when true)
             hidePagerOnEmpty: false, //removes pager if no rows
             preFill: false, //prefill table with empty rows
             sorting: true, // enable column sorting
@@ -561,7 +562,10 @@
                     lowerPage -= diff;
                 }
                 if (lowerPage < 1) lowerPage = 1;
-                if (upperPage < 5) upperPage = 5;
+                if (upperPage < 5 &&
+                    priv.options.hideEmptyPagesOnPager == false) {
+                    upperPage = 5;
+                }
 
                 var footToolbar = $('<div class="btn-toolbar"></div>').appendTo(footCell);
                 var footDiv = $('<div class="btn-group"></div>').appendTo(footToolbar);


### PR DESCRIPTION
Setting to false will continue current behaviour. Setting to true will
hide specific page numbers in pager where no data exists on those pages.
Only applicable when page count is less than 5. Prior to this change,
these page numbers were displayed but disabled. Now developer has option
to not display these page numbers in pager.