### PR TITLE
Support for all row-data in Cell-Format

### DIFF
--- a/jquery.watable.js
+++ b/jquery.watable.js
@@ -719,6 +719,26 @@
             switch (_data.cols[col].type) {
                 case "string":
                     val = val || '';
+					
+					var cellValue = format.f(val);
+                    if (format.indexOf("row.") >= 0) {
+                        var re = /row\.(\w*)/g;
+                        var m;
+                        while ((m = re.exec(cellValue)) !== null) {
+                            if (m.index === re.lastIndex) {
+                                re.lastIndex++;
+                            }                            
+                            if (m.length % 2 != 0) {
+                                priv.log("Format of formatstring is not correct. Formatstring: {0}".f(cellValue), true);
+                                continue;
+                            }
+                            var dataField = m[1];
+                            if (row[dataField]) {
+                                cellValue = cellValue.replace(new RegExp(m[0], 'gm'), row[dataField]);
+                            }
+                        }
+                    }
+
                     cell.html(format.f(val));
                     break;
                 case "number":


### PR DESCRIPTION
In addition to the '{0}' in cellFormat I added support to access all
other row/data-attributes.
Simple add 'row.xyz', where xyz is the attribute-name. This value
replaces row.xyz.

Example: 
Add a button with onClick to a cell in every row. Column should show clearText (name of device), onClick should execute function by deviceID: 

Table-Conf: 
...
cols: { 
...
device: { index: 3, type: "string", friendly: "Device", format: "<i class=\"icon-rocket pull-right\" style=\"cursor:pointer\" onclick=\"DisplayLinkedDetails('Device','row.deviceId')\"></i>{0}" },
...}

rows: [
...
{"id": "75f76cf1-16cf-4be8-810e-f28ef6fa5a37", "device": "test1", "deviceId": "b1e51d50-e8ef-41e1-bb62-dc78d01c416f"}
...
]